### PR TITLE
Standardize date formatting to UTC

### DIFF
--- a/app/bonn-ka-banjara/[slug]/page.tsx
+++ b/app/bonn-ka-banjara/[slug]/page.tsx
@@ -101,11 +101,12 @@ export default function SeriesEntryPage({ params }: SeriesEntryPageProps) {
                 <div className="flex items-center space-x-2 space-x-reverse">
                   <Calendar className="w-4 h-4" />
                   <span className="urdu-body-sm">
-                    {new Date(entry.publishedDate).toLocaleDateString('ur-PK', {
+                    {new Intl.DateTimeFormat('ur-PK', {
+                      timeZone: 'UTC',
                       year: 'numeric',
                       month: 'long',
                       day: 'numeric'
-                    })}
+                    }).format(new Date(entry.publishedDate))}
                   </span>
                 </div>
               </div>

--- a/app/bonn-ka-banjara/page.tsx
+++ b/app/bonn-ka-banjara/page.tsx
@@ -59,7 +59,9 @@ export default function BonnKaBanjaraPage() {
                       <div className="flex items-center space-x-2 space-x-reverse">
                         <Calendar className="w-4 h-4 text-gray-400" />
                         <span className="text-caption urdu-body-sm text-gray-500">
-                          {new Date(entry.publishedDate).toLocaleDateString('ur-PK')}
+                          {new Intl.DateTimeFormat('ur-PK', {
+                            timeZone: 'UTC'
+                          }).format(new Date(entry.publishedDate))}
                         </span>
                       </div>
                       

--- a/app/ur/bonn-ka-banjara/[slug]/page.tsx
+++ b/app/ur/bonn-ka-banjara/[slug]/page.tsx
@@ -101,11 +101,12 @@ export default function SeriesEntryPage({ params }: SeriesEntryPageProps) {
                 <div className="flex items-center space-x-2 space-x-reverse">
                   <Calendar className="w-4 h-4" />
                   <span className="urdu-text">
-                    {new Date(entry.publishedDate).toLocaleDateString('ur-PK', {
+                    {new Intl.DateTimeFormat('ur-PK', {
+                      timeZone: 'UTC',
                       year: 'numeric',
                       month: 'long',
                       day: 'numeric'
-                    })}
+                    }).format(new Date(entry.publishedDate))}
                   </span>
                 </div>
               </div>

--- a/app/ur/bonn-ka-banjara/page.tsx
+++ b/app/ur/bonn-ka-banjara/page.tsx
@@ -59,7 +59,9 @@ export default function BonnKaBanjaraPage() {
                       <div className="flex items-center space-x-2 space-x-reverse">
                         <Calendar className="w-4 h-4 text-gray-400" />
                         <span className="text-caption urdu-text text-gray-500">
-                          {new Date(entry.publishedDate).toLocaleDateString('ur-PK')}
+                          {new Intl.DateTimeFormat('ur-PK', {
+                            timeZone: 'UTC'
+                          }).format(new Date(entry.publishedDate))}
                         </span>
                       </div>
                       

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -143,7 +143,11 @@ export default function WorkPage() {
                       <p className="text-gray-600 text-sm mb-4">{talk.description}</p>
                       <div className="text-caption urdu-text">
                         <p>{talk.event} • {talk.location}</p>
-                        <p>{new Date(talk.date).toLocaleDateString('ur-PK')}</p>
+                        <p>
+                          {new Intl.DateTimeFormat('ur-PK', {
+                            timeZone: 'UTC'
+                          }).format(new Date(talk.date))}
+                        </p>
                       </div>
                     </div>
                   ))}
@@ -162,7 +166,11 @@ export default function WorkPage() {
                       <p className="text-gray-600 text-sm mb-4">{item.excerpt}</p>
                       <div className="text-caption urdu-text">
                         <p>{item.publication}</p>
-                        <p>{new Date(item.date).toLocaleDateString('ur-PK')}</p>
+                        <p>
+                          {new Intl.DateTimeFormat('ur-PK', {
+                            timeZone: 'UTC'
+                          }).format(new Date(item.date))}
+                        </p>
                       </div>
                     </div>
                   ))}

--- a/app/writing/[slug]/page.tsx
+++ b/app/writing/[slug]/page.tsx
@@ -82,11 +82,14 @@ export default function EssayPage({ params }: EssayPageProps) {
               <div className="flex flex-wrap items-center gap-6 text-sm text-muted-foreground">
                 <div className="flex items-center space-x-2">
                   <Calendar className="w-4 h-4" />
-                  <span>{new Date(essay.publishedDate).toLocaleDateString('en-US', {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric'
-                  })}</span>
+                  <span>
+                    {new Intl.DateTimeFormat('en-US', {
+                      timeZone: 'UTC',
+                      year: 'numeric',
+                      month: 'long',
+                      day: 'numeric'
+                    }).format(new Date(essay.publishedDate))}
+                  </span>
                 </div>
                 
                 <div className="flex items-center space-x-2">

--- a/components/EssayCard.tsx
+++ b/components/EssayCard.tsx
@@ -19,7 +19,7 @@ export function EssayCard({ essay }: EssayCardProps) {
   return (
     <motion.article
       className="project-card group"
-      data-pagefind-filter={`type:Essay${validDate ? `,year:${d.getFullYear()}` : ''}`}
+      data-pagefind-filter={`type:Essay${validDate ? `,year:${d.getUTCFullYear()}` : ''}`}
       data-pagefind-meta={`title:${essay.title},date:${essay.publishedDate}`}
       whileHover={shouldReduceMotion ? {} : { 
         y: -6,
@@ -32,7 +32,12 @@ export function EssayCard({ essay }: EssayCardProps) {
             <Calendar className="w-3 h-3 text-brand" />
             <span className="template-caption urdu-text">
               {validDate
-                ? new Intl.DateTimeFormat('ur-PK', { year: 'numeric', month: 'short', day: 'numeric' }).format(d)
+                ? new Intl.DateTimeFormat('ur-PK', {
+                    timeZone: 'UTC',
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric'
+                  }).format(d)
                 : ''}
             </span>
           </div>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -121,7 +121,10 @@ export function Footer() {
           {/* Copyright */}
           <motion.div variants={itemVariants}>
             <p className="template-caption urdu-text">
-              © {new Date().getFullYear()} عبدالباسط ظفر۔
+              © {new Intl.DateTimeFormat('ur-PK', {
+                timeZone: 'UTC',
+                year: 'numeric'
+              }).format(new Date())} عبدالباسط ظفر۔
             </p>
           </motion.div>
         </motion.div>


### PR DESCRIPTION
## Summary
- replace `toLocaleDateString` with `Intl.DateTimeFormat` using UTC in work and writing pages
- apply UTC-aware formatting across Bonn Ka Banjara pages and shared components
- ensure footer copyright year and search metadata derive from UTC dates

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b301abc790833085d6bb2e5b761bc0