### PR TITLE
feat: load pagefind script using Next.js Script component

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import type { Metadata } from 'next';
 import { Inter, Noto_Nastaliq_Urdu, Noto_Naskh_Arabic } from 'next/font/google';
+import Script from 'next/script';
 import { AccessibilityProvider } from '@/components/AccessibilityProvider';
 import { AccessibilityPanel } from '@/components/AccessibilityPanel';
 
@@ -52,7 +53,13 @@ export default function RootLayout({
   return (
     <html lang="ur" dir="rtl" className={`${inter.variable} ${notoNastaliq.variable} ${notoNaskh.variable}`}>
       <head>
-        <script defer src="/pagefind/pagefind-ui.js"></script>
+        <Script
+          src="/pagefind/pagefind-ui.js"
+          strategy="lazyOnload"
+          onError={(e) => {
+            console.error('Failed to load Pagefind UI', e);
+          }}
+        />
         <link href="/pagefind/pagefind-ui.css" rel="stylesheet" />
       </head>
       <body className={`${inter.variable} ${notoNastaliq.variable} ${notoNaskh.variable} font-urdu-body antialiased`}>


### PR DESCRIPTION
## Summary
- import and use Next.js `Script` for Pagefind UI loading
- log errors if the script fails to load

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b302b5658083309db44532a34986a3