### PR TITLE
refactor: move pagefind script to component

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,9 @@
 import './globals.css';
 import type { Metadata } from 'next';
 import { Inter, Noto_Nastaliq_Urdu, Noto_Naskh_Arabic } from 'next/font/google';
-import Script from 'next/script';
 import { AccessibilityProvider } from '@/components/AccessibilityProvider';
 import { AccessibilityPanel } from '@/components/AccessibilityPanel';
+import { PagefindScript } from '@/components/PagefindScript';
 
 const inter = Inter({ 
   subsets: ['latin'],
@@ -53,13 +53,7 @@ export default function RootLayout({
   return (
     <html lang="ur" dir="rtl" className={`${inter.variable} ${notoNastaliq.variable} ${notoNaskh.variable}`}>
       <head>
-        <Script
-          src="/pagefind/pagefind-ui.js"
-          strategy="lazyOnload"
-          onError={(e) => {
-            console.error('Failed to load Pagefind UI', e);
-          }}
-        />
+        <PagefindScript />
         <link href="/pagefind/pagefind-ui.css" rel="stylesheet" />
       </head>
       <body className={`${inter.variable} ${notoNastaliq.variable} ${notoNaskh.variable} font-urdu-body antialiased`}>

--- a/components/PagefindScript.tsx
+++ b/components/PagefindScript.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import Script from 'next/script';
+
+export function PagefindScript() {
+  return (
+    <Script
+      src="/pagefind/pagefind-ui.js"
+      strategy="lazyOnload"
+      onError={(e) => console.error('Failed to load Pagefind UI', e)}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- create PagefindScript component that lazily loads Pagefind UI script
- use PagefindScript component in layout instead of inline Script

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b32566de948330bd3e81068e8c65a7