### PR TITLE
fix: set locale for static pre-rendering

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import './globals.css';
 import { Header } from '@/components/Header';
 import { Footer } from '@/components/Footer';
-import { getCurrentLocale } from '../locales/server';
+import { getCurrentLocale, setStaticParamsLocale } from '../locales/server';
 import ClientProvider from '../context/ClientProvider';
 
 export default async function RootLayout({
@@ -9,6 +9,8 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  // Ensure locale is available during static pre-rendering
+  setStaticParamsLocale('ur');
   const locale = await getCurrentLocale();
 
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,8 +10,8 @@ export default async function RootLayout({
   children: React.ReactNode;
 }) {
   // Ensure locale is available during static pre-rendering
-  setStaticParamsLocale('ur');
-  const locale = await getCurrentLocale();
+  setStaticParamsLocale('en');
+  const locale = (await getCurrentLocale()) || 'en';
 
   return (
     // The 'dir' attribute is removed here to prevent layout flipping

--- a/context/ClientProvider.tsx
+++ b/context/ClientProvider.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { I18nProviderClient } from '../locales/client';
+import { LanguageProvider } from './LanguageContext';
 
 export default function ClientProvider({
   locale,
@@ -11,7 +12,7 @@ export default function ClientProvider({
 }) {
   return (
     <I18nProviderClient locale={locale} fallback={<>Loading...</>}>
-      {children}
+      <LanguageProvider>{children}</LanguageProvider>
     </I18nProviderClient>
   );
 }

--- a/context/ClientProvider.tsx
+++ b/context/ClientProvider.tsx
@@ -12,7 +12,7 @@ export default function ClientProvider({
 }) {
   return (
     <I18nProviderClient locale={locale} fallback={<>Loading...</>}>
-      <LanguageProvider>{children}</LanguageProvider>
+      <LanguageProvider initialLanguage={locale}>{children}</LanguageProvider>
     </I18nProviderClient>
   );
 }

--- a/context/LanguageContext.tsx
+++ b/context/LanguageContext.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+import { useChangeLocale, useCurrentLocale } from '@/locales/client';
+
+interface LanguageContextValue {
+  language: string;
+  setLanguage: (lang: string) => void;
+}
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+export function LanguageProvider({ children }: { children: React.ReactNode }) {
+  const language = useCurrentLocale();
+  const changeLocale = useChangeLocale();
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage: changeLocale }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export function useLanguage() {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    throw new Error('useLanguage must be used within a LanguageProvider');
+  }
+  return context;
+}

--- a/context/LanguageContext.tsx
+++ b/context/LanguageContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { createContext, useContext } from 'react';
-import { useChangeLocale, useCurrentLocale } from '@/locales/client';
+import { createContext, useContext, useState } from 'react';
+import { useChangeLocale } from '@/locales/client';
 
 interface LanguageContextValue {
   language: string;
@@ -10,12 +10,23 @@ interface LanguageContextValue {
 
 const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
 
-export function LanguageProvider({ children }: { children: React.ReactNode }) {
-  const language = useCurrentLocale();
+export function LanguageProvider({
+  initialLanguage,
+  children,
+}: {
+  initialLanguage: string;
+  children: React.ReactNode;
+}) {
   const changeLocale = useChangeLocale();
+  const [language, setLanguage] = useState(initialLanguage);
+
+  function handleSetLanguage(lang: string) {
+    setLanguage(lang);
+    changeLocale(lang);
+  }
 
   return (
-    <LanguageContext.Provider value={{ language, setLanguage: changeLocale }}>
+    <LanguageContext.Provider value={{ language, setLanguage: handleSetLanguage }}>
       {children}
     </LanguageContext.Provider>
   );

--- a/locales/server.ts
+++ b/locales/server.ts
@@ -1,4 +1,4 @@
-import { createI18nServer } from 'next-international/server';
+import { createI18nServer, setStaticParamsLocale } from 'next-international/server';
 import { cache } from 'react';
 
 export const { getI18n, getScopedI18n, getStaticParams, getCurrentLocale } = createI18nServer(
@@ -11,3 +11,5 @@ export const { getI18n, getScopedI18n, getStaticParams, getCurrentLocale } = cre
     cache: cache,
   },
 );
+
+export { setStaticParamsLocale };


### PR DESCRIPTION
## Summary
- export `setStaticParamsLocale` from `locales/server`
- ensure root layout sets a static locale before requesting current locale

## Testing
- `npm run lint`
- `npx next build` *(fails: Module not found: Can't resolve '@/context/LanguageContext')*

------
https://chatgpt.com/codex/tasks/task_e_68c7421a72a08330bec892f2e182a152