### PR TITLE
Refactor language context initialization

### DIFF
--- a/context/LanguageContext.tsx
+++ b/context/LanguageContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { createContext, useContext, useState } from 'react';
-import { useChangeLocale, useCurrentLocale } from '@/locales/client';
+import { useChangeLocale } from '@/locales/client';
 
 interface LanguageContextValue {
   language: string;
@@ -17,9 +17,8 @@ export function LanguageProvider({
   initialLanguage?: string;
   children: React.ReactNode;
 }) {
-  const currentLocale = useCurrentLocale();
   const changeLocale = useChangeLocale();
-  const [language, setLanguage] = useState(initialLanguage ?? currentLocale ?? 'en');
+  const [language, setLanguage] = useState(initialLanguage ?? 'en');
 
   function handleSetLanguage(lang: string) {
     if (!lang) return;


### PR DESCRIPTION
## Summary
- initialize LanguageContext with provided language or 'en'
- ensure ClientProvider passes a safe locale string to LanguageProvider

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c74de4000c833089fc9b854b7043d3