### PR TITLE
fix: add useLanguage import to home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { motion } from 'framer-motion';
 import Link from 'next/link';
 import { TimelineIcon } from '@/components/TimelineIcon';
+import { useLanguage } from '@/context/LanguageContext';
 
 // Animation variants for sections that fade/slide in
 const sectionVariants = {


### PR DESCRIPTION
## Summary
- fix missing useLanguage import in home page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Missing TinaCMS client configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c750cd70a88330a317b914488d47a0